### PR TITLE
Switch to CommandSpec on the Sponge side.

### DIFF
--- a/src/main/java/net/kaikk/mc/serverredirect/sponge/CommandExec.java
+++ b/src/main/java/net/kaikk/mc/serverredirect/sponge/CommandExec.java
@@ -1,72 +1,29 @@
 package net.kaikk.mc.serverredirect.sponge;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.spongepowered.api.Sponge;
-import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 
-public class CommandExec implements CommandCallable {
+import java.util.Collection;
+
+public class CommandExec implements CommandExecutor {
+
 	@Override
-	public CommandResult process(CommandSource source, String arguments) throws CommandException {
-		final String[] args = arguments.split("[\\s]+");
-		
-		if (args.length<2) {
-			source.sendMessage(this.getUsage(source));
-			return CommandResult.empty();
-		}
+	public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+		String address = args.<String>getOne("address").get();
+		Collection<Player> players = args.<Player>getAll("player");
 
-		if (args[1].equals("*")) {
-			ServerRedirect.sendToAll(args[0]);
+		if (players.size() == 0) {
+			ServerRedirect.sendToAll(address);
 		} else {
-			Optional<Player> playerToSend;
-			try {
-				playerToSend = Sponge.getServer().getPlayer(UUID.fromString(args[1]));
-			} catch (IllegalArgumentException e) {
-				playerToSend = Sponge.getServer().getPlayer(args[1]);
+			for (Player player : players) {
+				ServerRedirect.sendTo(player, address);
 			}
-			
-			if (!playerToSend.isPresent()) {
-				source.sendMessage(Text.of("Player "+args[1]+" not found"));
-				return CommandResult.empty();
-			}
-			
-			ServerRedirect.sendTo(playerToSend.get(), args[0]);
 		}
+
 		return CommandResult.success();
-	}
-
-	@Override
-	public List<String> getSuggestions(CommandSource source, String arguments, Location<World> targetPosition) throws CommandException {
-		return Collections.emptyList();
-	}
-
-	@Override
-	public boolean testPermission(CommandSource source) {
-		return source.hasPermission("serverredirect.command.redirect");
-	}
-
-	@Override
-	public Optional<Text> getShortDescription(CommandSource source) {
-		return Optional.empty();
-	}
-
-	@Override
-	public Optional<Text> getHelp(CommandSource source) {
-		return Optional.empty();
-	}
-
-	@Override
-	public Text getUsage(CommandSource source) {
-		return Text.of("Usage: /redirect <address> <PlayerName|PlayerUUID|\"*\">");
 	}
 }


### PR DESCRIPTION
The command specification itself also changes with this commit:

`/redirect <address> <player>*`

So a comparison from before to after:
`/redirect <address> * -> /redirect <address>`
`/redirect <address> <player> -> /redirect <address> <player>`
This commit also makes it so you can specify more than 1 player, but less than all players.

Honestly I don't see the need of being able to run it with a player's UUID, but I can add it if wanted.